### PR TITLE
docs: 更新环境变量配置说明中的文件名

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ cp server/config.template.json server/config.dev.json
 
 3. Configure environment variables:
 ```bash
-cp .env.example .env.local
+cp .env.template .env.local
 # Add the generated encryption key to .env.local
 ```
 


### PR DESCRIPTION
将.env.example改为.env.template