### PR TITLE
fix: resolve customer unread indicators

### DIFF
--- a/frontend/src/components/chat/staff/index.tsx
+++ b/frontend/src/components/chat/staff/index.tsx
@@ -172,13 +172,13 @@ export function StaffChat({ ticket, token, isTicketLoading }: StaffChatProps) {
   }, [messages, userId]);
 
   // Send read status when messages come into view
-  const handleMessageInView = (messageId: number) => {
+  const handleMessageInView = async (messageId: number) => {
     if (
       isTicketMember &&
       unreadMessages.has(messageId) &&
       !sentReadStatusRef.current.has(messageId)
     ) {
-      const readStatusSent = sendReadStatus(messageId);
+      const readStatusSent = await sendReadStatus(messageId);
       if (!readStatusSent) {
         return;
       }

--- a/frontend/src/components/chat/user/index.tsx
+++ b/frontend/src/components/chat/user/index.tsx
@@ -133,13 +133,15 @@ export function UserChat({
   }, [messages, userId]);
 
   // Send read status when messages come into view
-  const handleMessageInView = (messageId: number) => {
+  const handleMessageInView = async (messageId: number) => {
     if (
       unreadMessages.has(messageId) &&
       !sentReadStatusRef.current.has(messageId)
     ) {
-      // console.log("sendReadStatus", messageId);
-      sendReadStatus(messageId);
+      const readStatusSent = await sendReadStatus(messageId);
+      if (!readStatusSent) {
+        return;
+      }
       sentReadStatusRef.current.add(messageId);
       setUnreadMessages((prev) => {
         const next = new Set(prev);

--- a/frontend/src/hooks/use-ticket-websocket.ts
+++ b/frontend/src/hooks/use-ticket-websocket.ts
@@ -34,7 +34,7 @@ interface UseTicketWebSocketReturn {
     isInternal?: boolean,
   ) => Promise<void>;
   sendTypingIndicator: () => void;
-  sendReadStatus: (messageId: number) => boolean;
+  sendReadStatus: (messageId: number) => Promise<boolean>;
   closeConnection: () => void;
   sendCustomMsg: (props: wsMsgClientType) => void;
   withdrawMessage: (messageId: number) => void;
@@ -577,14 +577,11 @@ export function useTicketWebSocket({
 
   // 发送已读状态
   const sendReadStatus = useCallback(
-    (messageId: number) => {
-      const readAt = new Date().toISOString();
-      if (wsRef.current?.readyState !== WebSocket.OPEN) {
-        return false;
-      }
-
+    async (messageId: number) => {
       try {
-        wsRef.current.send(
+        const ws = await ensureConnected();
+        const readAt = new Date().toISOString();
+        ws.send(
           JSON.stringify({
             type: "message_read",
             userId,
@@ -602,7 +599,7 @@ export function useTicketWebSocket({
         return false;
       }
     },
-    [userId, readMessage, queryClient, onError],
+    [ensureConnected, userId, readMessage, queryClient, onError],
   );
 
   // 撤回消息

--- a/server/api/user/tickets.ts
+++ b/server/api/user/tickets.ts
@@ -136,11 +136,12 @@ async function getFilteredTicketIdsByStaffReadStatus(
 async function getFilteredTicketIdsByReadStatus(
   readStatus: "read" | "unread",
   currentUserId: number,
+  includeInternalMessages = true,
 ) {
   const db = connectDB();
 
   // 1. 使用子查询和窗口函数，为每个工单的所有消息按时间倒序排名
-  const latestMessageSubquery = db
+  const latestMessageQuery = db
     .select({
       id: schema.chatMessages.id,
       ticketId: schema.chatMessages.ticketId,
@@ -149,7 +150,12 @@ async function getFilteredTicketIdsByReadStatus(
         "rn",
       ),
     })
-    .from(schema.chatMessages)
+    .from(schema.chatMessages);
+
+  const latestMessageSubquery = (includeInternalMessages
+    ? latestMessageQuery
+    : latestMessageQuery.where(eq(schema.chatMessages.isInternal, false))
+  )
     .as("latest_messages");
 
   // 2. 构建查询的主体，包括 JOIN
@@ -305,6 +311,7 @@ async function getTicketsWithPagination(
     const readStatusTicketIds = await getFilteredTicketIdsByReadStatus(
       readStatus,
       userId,
+      role !== "customer",
     );
     // 如果没有匹配的工单，可以直接返回空，避免后续查询
     if (readStatusTicketIds.length === 0) {
@@ -345,6 +352,7 @@ async function getTicketsWithPagination(
         agent: basicUserCols,
         customer: basicUserCols,
         messages: {
+          where: (messages, { eq }) => eq(messages.isInternal, false),
           orderBy: [desc(schema.chatMessages.createdAt)],
           limit: 1,
           with: {


### PR DESCRIPTION
## Summary

Fix customer unread indicators that could remain stuck when the latest chat message is not visible to customers.

## Root Cause

Customer ticket detail only loads non-internal messages, but the customer ticket list and read/unread filtering used the latest message across all chat messages. If the latest message was internal, customers could not see or mark that message as read, so the sidebar unread dot could reappear after switching tickets.

## Changes

- Filter customer ticket-list latest-message lookup to customer-visible messages.
- Apply the same customer-visible filtering to read/unread ticket filtering.
- Make read-status sending wait for an open WebSocket connection.
- Only clear local unread state after read-status sending succeeds.

## Verification

- Ran `bun run typecheck`
- Ran `git diff --check upstream/main..origin/fix/user-unread`
- Confirmed PR branch comparison against `labring/tentix:main` is ahead by 1 commit with 4 changed files.

## Notes

Please merge with **Create a merge commit**.
